### PR TITLE
Add Block Embed render mode for practice overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roam-memo",
-  "version": "17",
+  "version": "21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roam-memo",
-      "version": "17",
+      "version": "21",
       "license": "ISC",
       "dependencies": {
         "@blueprintjs/core": "^3.50.4",

--- a/src/components/overlay/CardBlock.tsx
+++ b/src/components/overlay/CardBlock.tsx
@@ -79,32 +79,36 @@ const CardBlock = ({
         domUtils.simulateMouseClick(expandControlBtn);
       }
 
-      // Disconnect any existing observer
-      if (observerRef.current) {
-        observerRef.current.disconnect();
-      }
+      // In block embed mode, skip blur listeners and mutation observer
+      // to prevent focus stealing when the user is editing within the embed
+      if (!isBlockEmbedRef.current) {
+        // Disconnect any existing observer
+        if (observerRef.current) {
+          observerRef.current.disconnect();
+        }
 
-      // Add a mutation observer to detect dynamically added textareas (so we can add blur listeners)
-      const observer = new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-          if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-            mutation.addedNodes.forEach((node) => {
-              if (node instanceof HTMLElement) {
-                const newTextareas = node.querySelectorAll('textarea');
-                if (newTextareas.length > 0) {
-                  newTextareas.forEach((textarea) => {
-                    textarea.removeEventListener('blur', handleBlockBlur);
-                    textarea.addEventListener('blur', handleBlockBlur);
-                  });
+        // Add a mutation observer to detect dynamically added textareas (so we can add blur listeners)
+        const observer = new MutationObserver((mutations) => {
+          mutations.forEach((mutation) => {
+            if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+              mutation.addedNodes.forEach((node) => {
+                if (node instanceof HTMLElement) {
+                  const newTextareas = node.querySelectorAll('textarea');
+                  if (newTextareas.length > 0) {
+                    newTextareas.forEach((textarea) => {
+                      textarea.removeEventListener('blur', handleBlockBlur);
+                      textarea.addEventListener('blur', handleBlockBlur);
+                    });
+                  }
                 }
-              }
-            });
-          }
+              });
+            }
+          });
         });
-      });
 
-      observer.observe(ref.current, { childList: true, subtree: true });
-      observerRef.current = observer;
+        observer.observe(ref.current, { childList: true, subtree: true });
+        observerRef.current = observer;
+      }
     };
 
     // Create the debounced function only once

--- a/src/components/overlay/CardBlock.tsx
+++ b/src/components/overlay/CardBlock.tsx
@@ -29,14 +29,18 @@ const CardBlock = ({
 
   // Store the current refUid in a ref to access it inside the debounced function
   const refUidRef = React.useRef(refUid);
+  const isBlockEmbedRef = React.useRef(isBlockEmbed);
 
   // Create a ref for the mutation observer
   const observerRef = React.useRef<MutationObserver | null>(null);
 
-  // Update the ref when refUid changes
+  // Update the refs when props change
   React.useEffect(() => {
     refUidRef.current = refUid;
   }, [refUid]);
+  React.useEffect(() => {
+    isBlockEmbedRef.current = isBlockEmbed;
+  }, [isBlockEmbed]);
 
   // Create a ref to store the debounced function
   const debouncedFnRef = React.useRef<(() => void) | null>(null);
@@ -55,7 +59,11 @@ const CardBlock = ({
       if (!ref.current) return;
 
       await window.roamAlphaAPI.ui.components.unmountNode({ el: ref.current });
-      await window.roamAlphaAPI.ui.components.renderBlock({ uid: currentRefUid, el: ref.current });
+      await window.roamAlphaAPI.ui.components.renderBlock({
+        uid: currentRefUid,
+        el: ref.current,
+        ...(isBlockEmbedRef.current ? { 'zoom-path?': true } : {}),
+      });
 
       // Ensure block is not collapsed (so we can reveal children programatically)
       const roamBlockElm = ref.current.querySelector('.rm-block') as HTMLElement | null;

--- a/src/components/overlay/CardBlock.tsx
+++ b/src/components/overlay/CardBlock.tsx
@@ -12,12 +12,14 @@ const CardBlock = ({
   setHasCloze,
   breadcrumbs,
   showBreadcrumbs,
+  isBlockEmbed = false,
 }: {
   refUid: string;
   showAnswers: boolean;
   setHasCloze: (hasCloze: boolean) => void;
   breadcrumbs: BreadcrumbsType[];
   showBreadcrumbs: boolean;
+  isBlockEmbed?: boolean;
 }) => {
   const ref = React.useRef<HTMLDivElement | null>(null);
   const [renderedBlockElm, setRenderedBlockElm] = React.useState<HTMLElement | null>(null);
@@ -122,7 +124,11 @@ const CardBlock = ({
   return (
     <div>
       {breadcrumbs && showBreadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
-      <ContentWrapper ref={ref} showAnswers={showAnswers}></ContentWrapper>
+      {isBlockEmbed ? (
+        <BlockEmbedWrapper ref={ref}></BlockEmbedWrapper>
+      ) : (
+        <ContentWrapper ref={ref} showAnswers={showAnswers}></ContentWrapper>
+      )}
     </div>
   );
 };
@@ -151,6 +157,17 @@ const ContentWrapper = styled.div<{
     border-radius: 2px;
     padding: 0;
     margin: 0;
+  }
+`;
+
+const BlockEmbedWrapper = styled.div`
+  // To align bullet on the left + ref count on the right correctly
+  position: relative;
+  left: -14px;
+  width: calc(100% + 19px);
+
+  & .rm-block-separator {
+    min-width: unset;
   }
 `;
 

--- a/src/components/overlay/PracticeOverlay.tsx
+++ b/src/components/overlay/PracticeOverlay.tsx
@@ -303,7 +303,7 @@ const PracticeOverlay = ({
                   showAnswers={showAnswers}
                   setHasCloze={setHasCloze}
                   breadcrumbs={blockInfo.breadcrumbs}
-                  showBreadcrumbs={isBlockEmbedMode || showBreadcrumbs}
+                  showBreadcrumbs={showBreadcrumbs}
                   isBlockEmbed={isBlockEmbedMode}
                 />
               )}

--- a/src/components/overlay/PracticeOverlay.tsx
+++ b/src/components/overlay/PracticeOverlay.tsx
@@ -139,17 +139,20 @@ const PracticeOverlay = ({
   const [showAnswers, setShowAnswers] = React.useState(false);
   const [hasCloze, setHasCloze] = React.useState(true);
 
+  const isBlockEmbedMode = renderMode === RenderMode.BlockEmbed;
   const shouldShowAnswerFirst =
     renderMode === RenderMode.AnswerFirst && hasBlockChildrenUids && !showAnswers;
 
   // Reset showAnswers state
   React.useEffect(() => {
-    if (hasBlockChildren || hasCloze) {
+    if (isBlockEmbedMode) {
+      setShowAnswers(true);
+    } else if (hasBlockChildren || hasCloze) {
       setShowAnswers(false);
     } else {
       setShowAnswers(true);
     }
-  }, [hasBlockChildren, hasCloze, currentIndex, tagsList, selectedTag]);
+  }, [hasBlockChildren, hasCloze, currentIndex, tagsList, selectedTag, isBlockEmbedMode]);
 
   const onTagChange = async (tag) => {
     setCurrentIndex(0);
@@ -291,6 +294,7 @@ const PracticeOverlay = ({
                     setHasCloze={setHasCloze}
                     breadcrumbs={blockInfo.breadcrumbs}
                     showBreadcrumbs={false}
+                    isBlockEmbed={false}
                   />
                 ))
               ) : (
@@ -299,7 +303,8 @@ const PracticeOverlay = ({
                   showAnswers={showAnswers}
                   setHasCloze={setHasCloze}
                   breadcrumbs={blockInfo.breadcrumbs}
-                  showBreadcrumbs={showBreadcrumbs}
+                  showBreadcrumbs={isBlockEmbedMode || showBreadcrumbs}
+                  isBlockEmbed={isBlockEmbedMode}
                 />
               )}
             </>
@@ -455,10 +460,15 @@ const TagSelectorItem = ({ text, onClick, active, tagsList }) => {
     setShowTagSettings(!showTagSettings);
   };
 
-  const toggleRenderMode = () => {
+  const toggleSwapQA = () => {
     const newRenderMode =
-      tagRenderMode === RenderMode.Normal ? RenderMode.AnswerFirst : RenderMode.Normal;
+      tagRenderMode === RenderMode.AnswerFirst ? RenderMode.Normal : RenderMode.AnswerFirst;
+    setRenderMode(text, newRenderMode);
+  };
 
+  const toggleBlockEmbed = () => {
+    const newRenderMode =
+      tagRenderMode === RenderMode.BlockEmbed ? RenderMode.Normal : RenderMode.BlockEmbed;
     setRenderMode(text, newRenderMode);
   };
 
@@ -472,7 +482,22 @@ const TagSelectorItem = ({ text, onClick, active, tagsList }) => {
               <Blueprint.Switch
                 alignIndicator={Blueprint.Alignment.RIGHT}
                 checked={tagRenderMode === RenderMode.AnswerFirst}
-                onChange={toggleRenderMode}
+                onChange={toggleSwapQA}
+                disabled={tagRenderMode === RenderMode.BlockEmbed}
+                className="mb-0"
+              />
+            </div>
+          }
+          className="hover:bg-transparent hover:no-underline"
+        />
+        <Blueprint.MenuItem
+          text={
+            <div className="flex items-center justify-between">
+              <span className="text-xs">Block Embed</span>
+              <Blueprint.Switch
+                alignIndicator={Blueprint.Alignment.RIGHT}
+                checked={tagRenderMode === RenderMode.BlockEmbed}
+                onChange={toggleBlockEmbed}
                 className="mb-0"
               />
             </div>

--- a/src/models/practice.ts
+++ b/src/models/practice.ts
@@ -9,6 +9,7 @@ export enum CompletionStatus {
 export enum RenderMode {
   Normal = 'normal',
   AnswerFirst = 'answerFirst',
+  BlockEmbed = 'blockEmbed',
 }
 
 export type Today = {


### PR DESCRIPTION
## Summary
This PR introduces a new "Block Embed" render mode to the practice overlay, allowing cards to be displayed as embedded blocks with a zoom-path view. This complements the existing "Normal" and "Answer First" render modes.

The use case I have for this are cards where I just want to see the whole block on an SRS schedule vs doing Q&A/Cloze/etc quiz. Some examples for me include book highlights and dance notes

## Key Changes
- **New RenderMode**: Added `BlockEmbed` enum value to `RenderMode` in `src/models/practice.ts`
- **PracticeOverlay updates**:
  - Added logic to automatically show answers when in Block Embed mode
  - Pass `isBlockEmbed` prop to `CardBlock` components based on render mode
  - Split the render mode toggle into two separate controls: "Swap Q/A" (for AnswerFirst mode) and "Block Embed" (for BlockEmbed mode)
  - Made "Swap Q/A" toggle disabled when Block Embed mode is active
- **CardBlock component updates**:
  - Added `isBlockEmbed` prop to control rendering behavior
  - When Block Embed mode is enabled, pass `'zoom-path?': true` to the Roam API's `renderBlock` function
  - Conditionally render either `BlockEmbedWrapper` or `ContentWrapper` based on the mode
  - Added `BlockEmbedWrapper` styled component with adjusted positioning and styling for embedded block display

## Implementation Details
- Block Embed mode is mutually exclusive with Swap Q/A mode via UI controls
- The `isBlockEmbed` state is tracked via refs in `CardBlock` to ensure proper updates in debounced rendering functions
- Block Embed wrapper uses negative left margin and adjusted width to properly align bullets and ref counts
- When Block Embed is active, answers are automatically shown and the block is rendered with zoom-path enabled

https://claude.ai/code/session_01MGce5XAeMRFDULV4YkKX1c